### PR TITLE
Add coffeescript support

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -5,6 +5,9 @@ var _ = require("lodash");
 var gulp = require("gulp");
 var path = require("path");
 
+// register coffeescript to handle any coffee files
+require("coffee-script/register");
+
 var defaultOptions = {
   taskDirectory: "gulp-tasks",
   plugins: {},
@@ -38,14 +41,15 @@ module.exports = function (options) {
   function processDirectory(dir) {
     fs.readdirSync(dir).filter(function (filename) {
       var file = path.resolve(dir, filename);
-      return filename.slice(-3) === ".js" || fs.statSync(file).isDirectory();
+      var extname = path.extname(filename);
+      return extname === ".js" || extname === ".coffee" || fs.statSync(file).isDirectory();
     }).map(function (filename) {
       var file = path.resolve(dir, filename);
 
       if (fs.statSync(file).isDirectory()) {
         return { directory: true, filename: filename };
       } else {
-        var taskname = filename.slice(0, -3);
+        var taskname = path.basename(filename, path.extname(filename));
         taskname = taskname.split(options.filenameDelimiter).join(options.tasknameDelimiter);
 
         return { file: file, filename: filename, taskname: taskname };

--- a/build/index.js
+++ b/build/index.js
@@ -5,9 +5,6 @@ var _ = require("lodash");
 var gulp = require("gulp");
 var path = require("path");
 
-// register coffeescript to handle any coffee files
-require("coffee-script/register");
-
 var defaultOptions = {
   taskDirectory: "gulp-tasks",
   plugins: {},

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var _ = require('lodash');
 var gulp = require('gulp');
 var path = require('path');
 
+// register coffeescript to handle any coffee files
+require('coffee-script/register');
+
 var defaultOptions = {
   taskDirectory: 'gulp-tasks',
   plugins: {},
@@ -39,7 +42,8 @@ module.exports = function(options) {
     fs.readdirSync(dir)
       .filter(function(filename) {
         let file = path.resolve(dir, filename);
-        return (filename.slice(-3) === '.js' || fs.statSync(file).isDirectory());
+        var extname = path.extname(filename);
+        return (extname === '.js' || extname === '.coffee' || fs.statSync(file).isDirectory());
       })
       .map(function(filename) {
         let file = path.resolve(dir, filename);
@@ -47,7 +51,7 @@ module.exports = function(options) {
         if(fs.statSync(file).isDirectory()) {
           return { directory: true, filename: filename };
         } else {
-          let taskname = filename.slice(0, -3);
+          let taskname = path.basename(filename, path.extname(filename));
           taskname = taskname.split(options.filenameDelimiter).join(options.tasknameDelimiter);
 
           return { file: file, filename: filename, taskname: taskname };

--- a/index.js
+++ b/index.js
@@ -5,9 +5,6 @@ var _ = require('lodash');
 var gulp = require('gulp');
 var path = require('path');
 
-// register coffeescript to handle any coffee files
-require('coffee-script/register');
-
 var defaultOptions = {
   taskDirectory: 'gulp-tasks',
   plugins: {},

--- a/package.json
+++ b/package.json
@@ -13,12 +13,16 @@
     "test": "gulp test"
   },
   "author": "Reagan Thomas",
+  "contributors": [
+    "Jonathan Chapman <chafnan@gmail.com> (https://github.com/chafnan)"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/reaganthomas/gulp-simple-task-loader"
   },
   "dependencies": {
+    "coffee-script": "^1.9.1",
     "gulp": "^3.8.11",
     "lodash": "^3.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-simple-task-loader",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "A simple task loader for gulp",
   "keywords": [
     "gulp",
@@ -27,6 +27,7 @@
     "lodash": "^3.3.1"
   },
   "devDependencies": {
+    "coffee-script": "^1.9.1",
     "coveralls": "^2.11.2",
     "gulp-6to5": "^3.0.0",
     "gulp-bump": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-simple-task-loader",
-  "version": "1.0.32",
+  "version": "1.0.35",
   "description": "A simple task loader for gulp",
   "keywords": [
     "gulp",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,6 +4,9 @@ var assert = require('assert');
 var taskLoader = '../build/index.js';
 var gulp;
 
+// register coffeescript to handle any coffee files
+require('coffee-script/register');
+
 describe('gulp-simple-task-loader', function() {
 	beforeEach(function() {
 		delete require.cache[require.resolve(taskLoader)];

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -41,16 +41,17 @@ describe('gulp-simple-task-loader', function() {
 					tasknameDelimiter: ':'
 				});
 
-				assert.equal(Object.keys(gulp.tasks).length, 5);
+				assert.equal(Object.keys(gulp.tasks).length, 6);
 				done();
 			});
 
 			it('should allow ./ paths', function(done) {
 				require(taskLoader)({ taskDirectory: './test/test-tasks' });
 
-				assert.equal(Object.keys(gulp.tasks).length, 5);
+				assert.equal(Object.keys(gulp.tasks).length, 6);
 				done();
 			});
+
 		});
 	});
 
@@ -66,6 +67,18 @@ describe('gulp-simple-task-loader', function() {
 			gulp.tasks['only:fn'].fn();
 			done();
 		});
+
+    it('should exeute functions for coffee tests', function(done) {
+      require(taskLoader)({
+        taskDirectory: 'test/test-tasks',
+        plugins: { derp: 'herp' },
+        filenameDelimiter: '-',
+        tasknameDelimiter: ':'
+      });
+
+      gulp.tasks['coffee:task'].fn()
+      done()
+    });
 	});
 
 	describe('options', function() {

--- a/test/test-tasks/coffee-task.coffee
+++ b/test/test-tasks/coffee-task.coffee
@@ -1,0 +1,4 @@
+'use strict'
+
+module.exports = (gulp, config, plugins) ->
+  fn: ->


### PR DESCRIPTION
Gulp by default supports coffee script, but the task loader does not.  

Changed the process to allow a match for '.coffee' files.  Also, added a test to make sure the coffee file is used.

Let me know if you have any questions or would like it done differently.